### PR TITLE
Problem compiling on win32 platform when directory level has more than 2 deep.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -22,7 +22,7 @@ module.exports = class EmberHandlebarsCompiler
   compile: (data, path, callback) ->
     try
       tmplPath = path.replace @root, ''
-      tmplPath = tmplPath.replace '\\', '/'
+      tmplPath = tmplPath.replace /\\/g, '/'
       tmplPath = tmplPath.substr 0, tmplPath.length - sysPath.extname(tmplPath).length
       tmplName = "Ember.TEMPLATES['#{tmplPath}']"
       if @precompile is on


### PR DESCRIPTION
For example:

app/
templates/
artifact/
common/
propertyAddress.hbs

Actual result:

window.require.register("templates/artifact/common/propertyAddress", function(exports, require, module) {
Ember.TEMPLATES['artifact/common\propertyAddress'] = ...

Expected Results:

window.require.register("templates/artifact/common/propertyAddress", function(exports, require, module) {
Ember.TEMPLATES['artifact/common/propertyAddress'] = ...

Posible solution:

Updating line 25 of index.coffee to:

tmplPath = tmplPath.replace /\/g, '/'

Regards,

(sorry for my bad english)
