### PR TITLE
Restore the expected wrapper behavior

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,5 +1,4 @@
 sysPath     = require 'path'
-fs          = require 'fs'
 compileHBS  = require './ember-handlebars-compiler'
 
 module.exports = class EmberHandlebarsCompiler
@@ -8,15 +7,15 @@ module.exports = class EmberHandlebarsCompiler
   extension: 'hbs'
   precompile: off
   root: null
-  modulesPrefix: ''
+  modulesPrefix: 'module.exports = '
 
   constructor: (@config) ->
     if @config.files.templates.precompile is on
       @precompile = on
     if @config.files.templates.root?
       @root = sysPath.join 'app', @config.files.templates.root, sysPath.sep
-    if @config.modules.wrapper is on
-      @modulesPrefix = 'module.exports = '
+    if @config.modules.wrapper is off
+      @modulesPrefix = ''
     null
 
   compile: (data, path, callback) ->


### PR DESCRIPTION
Restore the expected wrapper behavior as bunch's config.modules.wrapper is either 'commonjs', 'amd', or false. The value is never true. See https://github.com/brunch/brunch/blob/master/docs/config.md#modules.

Remove unused `fs` import.
