### PR TITLE
Allow modulePrefix customization via config

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -16,6 +16,11 @@ module.exports = class EmberHandlebarsCompiler
       @root = sysPath.join 'app', @config.files.templates.root, sysPath.sep
     if @config.modules.wrapper is off
       @modulesPrefix = ''
+    else if @config.files.templates.wrapper?
+      if @config.files.templates.wrapper is off
+        @modulesPrefix = ''
+      else
+        @modulesPrefix = @config.files.templates.wrapper
     if @config.files.templates.defaultExtension?
       @extension = @config.files.templates.defaultExtension
     null

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -16,11 +16,11 @@ module.exports = class EmberHandlebarsCompiler
       @root = sysPath.join 'app', @config.files.templates.root, sysPath.sep
     if @config.modules.wrapper is off
       @modulesPrefix = ''
-    else if @config.files.templates.wrapper?
-      if @config.files.templates.wrapper is off
+    else if @config.files.templates.modulesPrefix?
+      if @config.files.templates.modulesPrefix is off
         @modulesPrefix = ''
       else
-        @modulesPrefix = @config.files.templates.wrapper
+        @modulesPrefix = @config.files.templates.modulesPrefix
     if @config.files.templates.defaultExtension?
       @extension = @config.files.templates.defaultExtension
     null


### PR DESCRIPTION
I customized my wrapper in my config.coffee for brunch. It was no longer CommonJS but since it also wasn't `false`, ember-handlebars-brunch kept its default module prefix of `module.exports =`.

This allows you to change this behavior in the `templates` section of your config.coffee:

``` coffeescript
files:
  templates:
    modulesPrefix: false # @modulesPrefix = ''
```
## 

``` coffeescript
files:
  templates:
    modulesPrefix: 'var template =  ' # @modulesPrefix = 'var template =  '
```
