### PR TITLE
modules.require is only valid if the wrapper is commonjs

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -14,7 +14,7 @@ module.exports = class EmberHandlebarsCompiler
       @precompile = on
     if @config.files.templates.root?
       @root = sysPath.join 'app', @config.files.templates.root, sysPath.sep
-    if @config.modules.wrapper is off
+    if @config.modules.wrapper isnt 'commonjs'
       @modulesPrefix = ''
     if @config.files.templates.defaultExtension?
       @extension = @config.files.templates.defaultExtension


### PR DESCRIPTION
I am not using commonjs to load my scripts. This removes the wrapper when using another loader.
