### PR TITLE
Peg ember-template-compiler to 1.7.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "coffee-script": "1.6.2",
     "handlebars": "~1.3.0",
-    "ember-template-compiler": "~1.5.1"
+    "ember-template-compiler": "1.7.x"
   },
   "devDependencies": {
     "mocha": "1.9.0",


### PR DESCRIPTION
Because 1.9.0-alpha has non-backwards-compatible changes.
Fixes #24.
