### PR TITLE
correctly resolve dependency paths

### DIFF
--- a/src/ember-handlebars-compiler.coffee
+++ b/src/ember-handlebars-compiler.coffee
@@ -6,8 +6,8 @@ module.exports = (->
   vm      = require 'vm'
   sysPath = require 'path'
 
-  compilerPath = sysPath.join __dirname, '..', 'node_modules/ember-template-compiler/vendor/', 'ember-template-compiler.js'
-  handlebarsPath = sysPath.join __dirname, '..', 'node_modules/handlebars/dist', 'handlebars.js'
+  compilerPath = require.resolve 'ember-template-compiler/vendor/ember-template-compiler.js'
+  handlebarsPath = require.resolve 'handlebars/dist/handlebars.js'
 
   compilerjs   = fs.readFileSync compilerPath, 'utf8'
   handlebarsjs   = fs.readFileSync handlebarsPath, 'utf8'


### PR DESCRIPTION
### Changes:
1. Use `require.resolve()` to correctly resolve paths to files in dependency packages [(see node v0.8.0 docs)](https://nodejs.org/docs/v0.8.0/api/modules.html#modules_all_together)

This allows the package to correctly function when `node_modules` directory uses a maximally flat directory structure.
### Testing:
- Unit tests using `npm run test` all pass
- Unit tests also pass with `./node_modules/handlebars` moved to `../node_modules/handlebars`
